### PR TITLE
Fix cached build error on picking

### DIFF
--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -8,7 +8,11 @@ defmodule Assembly.Build do
 
   require Logger
 
-  alias Assembly.{AdditiveMap, GenServers, Option, Repo, Schemas}
+  alias Assembly.AdditiveMap
+  alias Assembly.GenServers
+  alias Assembly.Option
+  alias Assembly.Schemas
+  alias Assembly.Repo
 
   @supervisor Assembly.BuildSupervisor
   @registry Assembly.BuildRegistry
@@ -137,7 +141,7 @@ defmodule Assembly.Build do
   """
   @spec pick_build(String.t()) :: {:ok, Schemas.Build.t()} | {:error, :not_found}
   def pick_build(id) do
-    with build when not is_nil(build) <- get_build(id),
+    with build when not is_nil(build) <- Repo.get_by(Schemas.Build, hal_id: id),
          {:ok, updated_build} <- update_build(build, %{"status" => "inprogress"}) do
       {:ok, updated_build}
     else

--- a/test/assembly/build_test.exs
+++ b/test/assembly/build_test.exs
@@ -111,7 +111,7 @@ defmodule Assembly.BuildsTest do
     end
 
     test "returns not found error if build is not pickable" do
-      assert {:error, :not_found} = Build.pick_build("nope")
+      assert {:error, :not_found} = Build.pick_build("0000")
     end
   end
 


### PR DESCRIPTION
Picking builds has been failing with:

```elixir
** (Ecto.StaleEntryError) attempted to update a stale struct:

%Assembly.Schemas.Build{__meta__: #Ecto.Schema.Metadata<:loaded, "builds">, hal_id: 17895, id: "6e34c55a-2f1b-4de7-a881-fa3bcdb27eb3", inserted_at: ~N[2021-11-15 15:10:34], model: "bag-bkpk2", options: [%Assembly.Schemas.Option{__meta__: #Ecto.Schema.Metadata<:loaded, "build_components">, build: #Ecto.Association.NotLoaded<association :build is not loaded>, build_id: "6e34c55a-2f1b-4de7-a881-fa3bcdb27eb3", component_id: "12189", id: "98428a6f-afbf-4c25-9a13-4f7ffccb916a", inserted_at: ~N[2021-11-15 15:10:34], quantity: 1, updated_at: ~N[2021-11-15 15:10:34]}], order_id: "133307", status: :ready, updated_at: ~N[2021-11-15 15:10:34]}
```

This means that we got the build cached in the GenServer and when we try to update it in the DB (Which has been changed asynchronously and not synced to the GenServer), Ecto complains about the data difference. The solution here fetches the build from the DB instead of the cache before updating.