### PR TITLE
Fix dialyzer errors and other quality improvements

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,4 @@
+[
+  # Warnings from `Cachex.Hook.Schema.handle_info/2` that we couldn't touch
+  {"lib/cachex/hook.ex", :pattern_match_cov}
+]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,5 +4,6 @@
     "*.{ex,exs}",
     "{config,lib,test}/**/*.{ex,exs}"
   ],
+  subdirectories: ["priv/*/migrations"],
   line_length: 120
 ]

--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -67,7 +67,7 @@ defmodule Assembly.Build do
       _ -> nil
     end
   catch
-    :exit, {:normal, _} -> :ok
+    :exit, {:normal, _} -> nil
   end
 
   @doc """
@@ -166,12 +166,15 @@ defmodule Assembly.Build do
   """
   @spec delete_build(String.t()) :: {:ok, Schemas.Build.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
   def delete_build(id) do
-    with build when not is_nil(build) <- get_build(id),
-         [{pid, _value}] <- Registry.lookup(@registry, to_string(id)) do
-      GenServer.cast(pid, :delete_build)
+    with build when not is_nil(build) <- Repo.get_by(Schemas.Build, hal_id: id) do
+      case Registry.lookup(@registry, to_string(id)) do
+        [{pid, _value}] -> GenServer.cast(pid, :delete_build)
+        _other -> :noop
+      end
+
       Repo.delete(build)
     else
-      [] -> {:error, :not_found}
+      nil -> {:error, :not_found}
     end
   end
 

--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -166,15 +166,17 @@ defmodule Assembly.Build do
   """
   @spec delete_build(String.t()) :: {:ok, Schemas.Build.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
   def delete_build(id) do
-    with build when not is_nil(build) <- Repo.get_by(Schemas.Build, hal_id: id) do
-      case Registry.lookup(@registry, to_string(id)) do
-        [{pid, _value}] -> GenServer.cast(pid, :delete_build)
-        _other -> :noop
-      end
+    case Repo.get_by(Schemas.Build, hal_id: id) do
+      build when not is_nil(build) ->
+        case Registry.lookup(@registry, to_string(id)) do
+          [{pid, _value}] -> GenServer.cast(pid, :delete_build)
+          _other -> :noop
+        end
 
-      Repo.delete(build)
-    else
-      nil -> {:error, :not_found}
+        Repo.delete(build)
+
+      nil ->
+        {:error, :not_found}
     end
   end
 

--- a/lib/assembly/component_cache.ex
+++ b/lib/assembly/component_cache.ex
@@ -59,10 +59,11 @@ defmodule Assembly.ComponentCache do
   @doc """
   A `Cachex.Hook` that handles notify builds when anything changes.
   """
-  def handle_notify({action, _params} = msg, _results, _last) when action in [:put, :clear] do
-    Assembly.Build.update_build_status()
+  def handle_notify({action, _params} = msg, _results, _last) do
+    if action in [:put, :clear] do
+      Assembly.Build.update_build_status()
+    end
+
     {:ok, msg}
   end
-
-  def handle_notify(msg, _, _), do: {:ok, msg}
 end

--- a/lib/assembly/component_cache.ex
+++ b/lib/assembly/component_cache.ex
@@ -59,11 +59,10 @@ defmodule Assembly.ComponentCache do
   @doc """
   A `Cachex.Hook` that handles notify builds when anything changes.
   """
-  def handle_notify({action, _params} = msg, _results, _last) do
-    if action in [:put, :clear] do
-      Assembly.Build.update_build_status()
-    end
-
+  def handle_notify({action, _params} = msg, _results, _last) when action in [:put, :clear] do
+    Assembly.Build.update_build_status()
     {:ok, msg}
   end
+
+  def handle_notify(msg, _, _), do: {:ok, msg}
 end

--- a/lib/assembly/demand.ex
+++ b/lib/assembly/demand.ex
@@ -10,7 +10,7 @@ defmodule Assembly.Demand do
 
   use GenServer
 
-  alias Assembly.{Build, Option}
+  alias Assembly.Option
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)

--- a/mix.exs
+++ b/mix.exs
@@ -11,9 +11,6 @@ defmodule Assembly.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),
-      preferred_cli_env: [
-        dialyzer: :test
-      ],
       releases: [
         assembly: [
           include_executables_for: [:unix],

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,9 @@ defmodule Assembly.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),
+      preferred_cli_env: [
+        dialyzer: :test
+      ],
       releases: [
         assembly: [
           include_executables_for: [:unix],
@@ -39,6 +42,7 @@ defmodule Assembly.MixProject do
   # Setup dialyzer plt files in /priv for easier caching.
   defp dialyzer do
     [
+      ignore_warnings: ".dialyzer_ignore.exs",
       plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Code.put_compiler_option(:warnings_as_errors, true)
+
 Mox.defmock(Assembly.MockEvents, for: Assembly.Events)
 
 Ecto.Adapters.SQL.Sandbox.mode(Assembly.Repo, :manual)


### PR DESCRIPTION
* Fixes dialyzer warning in `delete_build/1` which probably points to same bug fixed earlier in `update_build/1`.
* Cleanup compiler warnings due to unused aliases.
* Make formatter handle migration files too.
* Ignore dialyzer warning for Cachex library that's out of our control.