### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+      - id: check-deps
+        name: Check for unlocked dependencies
+        always_run: true
+        pass_filenames: false
+        language: system
+        entry: "mix"
+        args: ["deps.get"]
+      - id: format
+        name: Elixir Format
+        files: ".*\\.exs?"
+        language: system
+        entry: "mix"
+        args: ["format"]
+      - id: credo
+        name: Check Elixir code style with credo
+        files: ".*\\.exs?"
+        language: system
+        entry: "mix"
+        args: ["credo", "-a"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ builds will be created.
 have no options, while others have many. A Thelio desktop for instance has many
 options to select, like the GPU, CPU, etc.
 
-## Setup
+## Development Setup
 
 First, make sure you are running the dependency services with `docker-compose`:
 
@@ -71,4 +71,12 @@ Then run this to test the project:
 
 ```shell
 mix test
+```
+
+### Contributing
+
+This project makes use of [https://pre-commit.com/](https://pre-commit.com/) to ensure code quality before pushing it to Git. While this is not a requirement, it's encouraged to have `pre-commit` installed with `pip install pre-commit`, and the in this project root, run:
+
+```shell
+pre-commit install
 ```


### PR DESCRIPTION
Add git hooks using https://pre-commit.com/ to keep commits saner and prevent extra CI work.