### PR TITLE
log all unexpected errors when passing off to genserver

### DIFF
--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -112,7 +112,7 @@ defmodule Assembly.Build do
     with %{changes: changes} = changeset when map_size(changes) > 0 <- Schemas.Build.changeset(build, attrs),
          {:ok, updated_build} <- Repo.update(changeset),
          preloaded_build <- Repo.preload(updated_build, [:options]),
-         {:ok, _} <- update_registry_build(preloaded_build) do
+         {:ok, _} <- update_preloaded_build(preloaded_build) do
       {:ok, preloaded_build}
     else
       # No-op if no changes occur. Avoids sending build updated messages on the
@@ -123,7 +123,7 @@ defmodule Assembly.Build do
     end
   end
 
-  defp update_preloaded_build(preloaded_build) do # TODO rename
+  defp update_preloaded_build(preloaded_build) do
     case Registry.lookup(@registry, to_string(preloaded_build.hal_id)) do
       [{pid, _value}] ->
         GenServer.cast(pid, {:update_build, preloaded_build})

--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -117,8 +117,12 @@ defmodule Assembly.Build do
     else
       # No-op if no changes occur. Avoids sending build updated messages on the
       # queue, recalculating status, etc.
-      %{errors: []} -> {:ok, build}
-      %{changes: _} = changeset -> {:error, changeset}
+      %{errors: []} ->
+        {:ok, build}
+
+      %{changes: _} = changeset ->
+        {:error, changeset}
+
       error ->
         Logger.error("unexpected error occurred while updating build: #{inspect(error)}")
         {:error, error}

--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -111,21 +111,27 @@ defmodule Assembly.Build do
   def update_build(build, attrs) do
     with %{changes: changes} = changeset when map_size(changes) > 0 <- Schemas.Build.changeset(build, attrs),
          {:ok, updated_build} <- Repo.update(changeset),
-         preloaded_build <- Repo.preload(updated_build, [:options]) do
-      case Registry.lookup(@registry, to_string(preloaded_build.hal_id)) do
-        [{pid, _value}] ->
-          GenServer.cast(pid, {:update_build, preloaded_build})
-          {:ok, preloaded_build}
-
-        _ ->
-          DynamicSupervisor.start_child(@supervisor, {GenServers.Build, preloaded_build})
-          {:ok, preloaded_build}
-      end
+         preloaded_build <- Repo.preload(updated_build, [:options]),
+         {:ok, _} <- update_registry_build(preloaded_build) do
+      {:ok, preloaded_build}
     else
-      # No-op if no changes occure. Avoids sending build updated messages on the
+      # No-op if no changes occur. Avoids sending build updated messages on the
       # queue, recalculating status, etc.
       %{errors: []} -> {:ok, build}
       %{changes: _} = changeset -> {:error, changeset}
+      error -> Logger.error("unexpected error occurred while updating build: #{inspect(error)}")
+    end
+  end
+
+  defp update_preloaded_build(preloaded_build) do # TODO rename
+    case Registry.lookup(@registry, to_string(preloaded_build.hal_id)) do
+      [{pid, _value}] ->
+        GenServer.cast(pid, {:update_build, preloaded_build})
+        {:ok, preloaded_build}
+
+      _ ->
+        DynamicSupervisor.start_child(@supervisor, {GenServers.Build, preloaded_build})
+        {:ok, preloaded_build}
     end
   end
 

--- a/lib/assembly/build.ex
+++ b/lib/assembly/build.ex
@@ -119,7 +119,9 @@ defmodule Assembly.Build do
       # queue, recalculating status, etc.
       %{errors: []} -> {:ok, build}
       %{changes: _} = changeset -> {:error, changeset}
-      error -> Logger.error("unexpected error occurred while updating build: #{inspect(error)}")
+      error ->
+        Logger.error("unexpected error occurred while updating build: #{inspect(error)}")
+        {:error, error}
     end
   end
 


### PR DESCRIPTION
Some errors might be dropped unless we check for matches explicitly. 